### PR TITLE
Fix power_generation_total parsing

### DIFF
--- a/js/BtOneApp.js
+++ b/js/BtOneApp.js
@@ -113,7 +113,7 @@ class BtOneApp extends BLEDevice {
     data['charging_amp_hours_today'] = dataView.getInt16(37);
     data['discharging_amp_hours_today'] = dataView.getInt16(39);
     data['power_generation_today'] = parseFloat((dataView.getInt16(41) * 0.001).toFixed(3));
-    data['power_generation_total'] = parseFloat((dataView.getInt16(41) * 0.001).toFixed(3));
+    data['power_generation_total'] = parseFloat((dataView.getInt32(59) * 0.001).toFixed(3));
     const chargingStatusCode = dataView.getInt8(68);
     data['charging_status'] = CHARGING_STATE[chargingStatusCode];
 


### PR DESCRIPTION
The parsing logic for `power_generation_total` was just a copy & paste from `power_generation_today`.
This PR corrects it (not that your `index.html` file uses it, but this way it's correct for anyone who modifies the index page)

Screenshot showing the info correctly parsed & being displayed in my modified index page:
![image](https://github.com/user-attachments/assets/25422e99-16d8-49c4-9825-85aa0ceafb1a)
